### PR TITLE
Fix screenshot functionality and add API key based ratelimiting

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -178,7 +178,10 @@ version = "0.1.0"
 dependencies = [
  "async-openai",
  "axum",
+ "dashmap",
  "dotenv",
+ "governor",
+ "once_cell",
  "serde",
  "sqlx",
  "tokio",
@@ -408,6 +411,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +576,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -719,6 +742,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "governor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444405bbb1a762387aa22dd569429533b54a1d8759d35d3b64cb39b0293eaa19"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.3",
+ "hashbrown 0.15.5",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +779,11 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1254,6 +1305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1508,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1574,6 +1652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2040,6 +2127,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2024"
 [dependencies]
 async-openai = "0.29.2"
 axum = "0.8.4"
+dashmap = "6.1.0"
 dotenv = "0.15.0"
+governor = "0.10.1"
+once_cell = "1.21.3"
 serde = "1.0.219"
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono"] }
 tokio = { version = "1", features = ["full"] }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod openai;
 pub mod database;
+pub mod ratelimit;

--- a/backend/src/openai.rs
+++ b/backend/src/openai.rs
@@ -25,9 +25,16 @@ pub async fn get_step_by_step_guidance(image_b64: &str) -> Result<String, Box<dy
         name: None,
     };
 
+    // Handle both raw base64 and data URLs
+    let image_url = if image_b64.starts_with("data:") {
+        image_b64.to_string()
+    } else {
+        format!("data:image/jpeg;base64,{}", image_b64)
+    };
+
     let image_content = ChatCompletionRequestMessageContentPartImage {
         image_url: ImageUrl {
-            url: format!("data:image/jpeg;base64,{}", image_b64),
+            url: image_url,
             detail: None,
         },
     };
@@ -68,9 +75,16 @@ pub async fn get_final_answer(image_b64: &str) -> Result<String, Box<dyn std::er
         name: None,
     };
 
+    // Handle both raw base64 and data URLs
+    let image_url = if image_b64.starts_with("data:") {
+        image_b64.to_string()
+    } else {
+        format!("data:image/jpeg;base64,{}", image_b64)
+    };
+
     let image_content = ChatCompletionRequestMessageContentPartImage {
         image_url: ImageUrl {
-            url: format!("data:image/jpeg;base64,{}", image_b64),
+            url: image_url,
             detail: None,
         },
     };

--- a/backend/src/ratelimit.rs
+++ b/backend/src/ratelimit.rs
@@ -1,0 +1,27 @@
+use governor::{Quota, clock::DefaultClock, state::InMemoryState, RateLimiter};
+use std::{num::NonZeroU32, sync::Arc};
+use dashmap::DashMap;
+use once_cell::sync::Lazy;
+use governor::state::NotKeyed;
+
+type ApiKey = String;
+
+const RATE_LIMIT: u32 = 3;
+
+// Global, thread-safe map: API key → rate limiter
+static API_KEY_LIMITERS: Lazy<DashMap<ApiKey, Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock>>>> =
+    Lazy::new(DashMap::new);
+
+/// Checks if the given API key is within its rate limit.
+/// Returns `true` if allowed, `false` if rate limit is exceeded.
+pub fn check_rate_limit(api_key: &str) -> bool {
+    let limiter = API_KEY_LIMITERS
+        .entry(api_key.to_string())
+        .or_insert_with(|| {
+            let quota = Quota::per_minute(NonZeroU32::new(RATE_LIMIT).unwrap());
+            Arc::new(RateLimiter::direct_with_clock(quota, DefaultClock::default()))
+        })
+        .clone();
+
+    limiter.check().is_ok()
+}

--- a/frontend/maths-online-app/src-tauri/tauri.conf.json
+++ b/frontend/maths-online-app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "maths-online-app",
+  "productName": "Maths Online App",
   "version": "0.1.0",
   "identifier": "com.connorakey.dev",
   "build": {


### PR DESCRIPTION
This pull request introduces rate limiting for API requests in the backend, improves image handling for OpenAI endpoints, and adds several new dependencies to support these features. The most significant changes are the addition of per-API-key rate limiting to prevent abuse and the enhancement of image input support. Below are the top changes grouped by theme:

**Rate Limiting Implementation:**

* Added a new `ratelimit` module (`backend/src/ratelimit.rs`) that uses the `governor`, `dashmap`, and `once_cell` crates to enforce a limit of 3 requests per minute per API key. The `check_rate_limit` function is now called in the OpenAI endpoint to reject requests exceeding the limit. [[1]](diffhunk://#diff-fab3e3e6c7c03c49c9927aa6b8d3230d3c75f553632dcf5ba0bddc9e836171daR1-R27) [[2]](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dR6-R7) [[3]](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dR76-R81) [[4]](diffhunk://#diff-9cd99344677f61bc58fc3f6c29c3f7e212d40afdb18e489a6250cdb7191ab6a6R3)
* Updated `Cargo.toml` to include new dependencies: `dashmap`, `governor`, and `once_cell` for thread-safe rate limiting.

**OpenAI Image Handling Improvements:**

* Improved image input handling in both `get_step_by_step_guidance` and `get_final_answer` functions to accept either raw base64 strings or full data URLs, making the API more robust to different input formats. [[1]](diffhunk://#diff-ed914f4f0eac4a924413b73b7fa42ec16d024d82f9d282dd250567e1f41c732fR28-R37) [[2]](diffhunk://#diff-ed914f4f0eac4a924413b73b7fa42ec16d024d82f9d282dd250567e1f41c732fR78-R87)

**Frontend Configuration:**

* Updated the product name in the Tauri configuration file to "Maths Online App" for improved branding consistency.